### PR TITLE
Node cache maps

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,24 +6,25 @@ import {readFile} from 'fs/promises';
 import {debugDump} from './syntax/pyracantha/Debug.js';
 
 yargs(hideBin(process.argv))
-  .command<{path: string, dump: boolean, time: boolean}>(
+  .command<{path: string; dump: boolean; time: boolean}>(
     ['parse <path>', '$0'],
     'parse a HTML file and output the AST',
     (args) => {
-      return args.positional('path', {
-        describe: 'path to the file',
-        type: 'string'
-      })
-      .option('dump', {
-        describe: 'Dump the parsed file to standard output.',
-        boolean: true,
-        default: true,
-      })
-      .option('time', {
-        describe: 'Emit timings for to standard output.',
-        boolean: true,
-        default: false,
-      });
+      return args
+        .positional('path', {
+          describe: 'path to the file',
+          type: 'string'
+        })
+        .option('dump', {
+          describe: 'Dump the parsed file to standard output.',
+          boolean: true,
+          default: true
+        })
+        .option('time', {
+          describe: 'Emit timings for to standard output.',
+          boolean: true,
+          default: false
+        });
     },
     async (argv) => {
       if (argv.time) {

--- a/src/syntax/pyracantha/Djb.ts
+++ b/src/syntax/pyracantha/Djb.ts
@@ -1,0 +1,36 @@
+const DJB_INIT = 5381;
+
+export class Djb {
+  private hash: number;
+
+  public constructor() {
+    this.hash = DJB_INIT;
+  }
+
+  /**
+   * Get the current value of the hash code in this hasher.
+   */
+  public finish(): number {
+    return this.hash;
+  }
+
+  /**
+   * Write a number into the hash.
+   *
+   * @param value The value to combine.
+   */
+  public writeNumber(value: number): void {
+    this.hash = this.hash + (this.hash << 5) + value;
+  }
+
+  /**
+   * Write a string value into the hash.
+   *
+   * @param s The string to add.
+   */
+  public writeString(value: string) {
+    for (let i = 0; i < value.length && i < 50; i++) {
+      this.writeNumber(value.charCodeAt(i));
+    }
+  }
+}

--- a/src/syntax/pyracantha/GreenNode.ts
+++ b/src/syntax/pyracantha/GreenNode.ts
@@ -1,5 +1,6 @@
-import {SyntaxKind} from './Pyracantha';
-import {GreenToken} from './GreenToken';
+import {SyntaxKind} from './Pyracantha.js';
+import {GreenToken} from './GreenToken.js';
+import {Djb} from './Djb.js';
 
 /**
  * # Green Node
@@ -10,14 +11,13 @@ import {GreenToken} from './GreenToken';
  * enable sharing of portions of the syntax tree.
  */
 export class GreenNode {
+  private hashCode: number | undefined;
+
   /**
    * The width of this node. This is cached based on the width of the node's
    * children
    */
   public width: number;
-
-  // TODO: Is this best?
-  public hash: number;
 
   /**
    * # Create a Green Node
@@ -36,7 +36,23 @@ export class GreenNode {
       (prev, current) => prev + current.textLength,
       0
     );
-    this.hash = Math.random();
+    this.hashCode = undefined;
+  }
+
+  /**
+   * Get the hash code for this element.
+   */
+  public get hash(): number {
+    if (this.hashCode === undefined) {
+      var hash = new Djb();
+      hash.writeNumber(this.kind);
+      for (var element of this.children) {
+        hash.writeNumber(element.hash);
+      }
+      this.hashCode = hash.finish();
+    }
+
+    return this.hashCode;
   }
 
   /**

--- a/src/syntax/pyracantha/GreenToken.ts
+++ b/src/syntax/pyracantha/GreenToken.ts
@@ -1,3 +1,4 @@
+import {Djb} from './Djb.js';
 import {SyntaxKind} from './Pyracantha';
 
 /**
@@ -8,8 +9,7 @@ import {SyntaxKind} from './Pyracantha';
  * lexical analysis phase, or may be composites of several lexical tokens.
  */
 export class GreenToken {
-  // TODO: Hashing?
-  public hash: number;
+  private hashCode: number | undefined;
 
   /**
    * # Create a Green Token
@@ -21,7 +21,21 @@ export class GreenToken {
    * @param text The text of this token
    */
   public constructor(public kind: SyntaxKind, public text: string) {
-    this.hash = Math.random();
+    this.hashCode = undefined;
+  }
+
+  /**
+   * Get the hash code for this element.
+   */
+  public get hash(): number {
+    if (this.hashCode === undefined) {
+      var hash = new Djb();
+      hash.writeNumber(this.kind);
+      hash.writeString(this.text);
+      this.hashCode = hash.finish();
+    }
+
+    return this.hashCode;
   }
 
   /**


### PR DESCRIPTION
Work to actually start caching nodes in the node cache


 * [x] What about hash codes on entries? Do we want them to be owned by the node cache instead?
 * [x] Entries API so we don't have to do two lookups for the get / insert case (this will be common).
 * [x] Better limiting on the size of bucket arrays?
 * [x] Do we need to cache _long_ tokens? (nope, makes things worse to cache fewer tokens).